### PR TITLE
Support for upserting models with fields containing custom db_column

### DIFF
--- a/querybuilder/query.py
+++ b/querybuilder/query.py
@@ -1237,7 +1237,8 @@ class Query(object):
             placeholders = []
             for field in all_fields:
                 # Convert field value to db value
-                sql_args.append(field.get_db_prep_save(getattr(row, field.column), self.connection))
+                # Use attname here to support fields with custom db_column names
+                sql_args.append(field.get_db_prep_save(getattr(row, field.attname), self.connection))
                 placeholders.append('%s')
             row_values.append('({0})'.format(', '.join(placeholders)))
         row_values_sql = ', '.join(row_values)

--- a/querybuilder/tests/migrations/0001_initial.py
+++ b/querybuilder/tests/migrations/0001_initial.py
@@ -64,6 +64,7 @@ class Migration(migrations.Migration):
                 ('field6', models.CharField(max_length=16)),
                 ('field7', models.CharField(max_length=16)),
                 ('field8', json_field),
+                ('_field_custom_db_column', models.CharField(max_length=16, null=True, default='foo', db_column='field_custom_db_column')),
             ],
         ),
         migrations.CreateModel(

--- a/querybuilder/tests/models.py
+++ b/querybuilder/tests/models.py
@@ -52,6 +52,7 @@ class Uniques(models.Model):
     field6 = models.CharField(max_length=16)
     field7 = models.CharField(max_length=16)
     field8 = JSONField(default={})
+    _field_custom_db_column = models.CharField(max_length=16, null=True, default='foo', db_column='field_custom_db_column')
 
     class Meta:
         unique_together = ('field6', 'field7')

--- a/querybuilder/tests/upsert_tests.py
+++ b/querybuilder/tests/upsert_tests.py
@@ -216,3 +216,20 @@ class TestUpsert(QueryTestCase):
         self.assertEqual(users[0].email, 'user1change')
         self.assertEqual(users[1].email, 'user2')
         self.assertEqual(users[2].email, 'user3')
+
+    def test_upsert_custom_db_column(self):
+        """
+        Makes sure upserting a model containing a field with a custom db_column name works.
+        """
+
+        model = Uniques(field1='1', _field_custom_db_column='test')
+
+        Query().from_table(Uniques).upsert(
+            [model],
+            unique_fields=['field1'],
+            update_fields=[]
+        )
+
+        saved_model = Uniques.objects.get(field1='1')
+
+        self.assertEqual(saved_model._field_custom_db_column, 'test')


### PR DESCRIPTION
Currently if you have a field where you specify a db_column and try to upsert it will throw an AttributeError. This change fixes that by using the field's `attname` instead of `column` to get the value.

The only case this this would break backwards compatibility that I can think of is if a model has a property defined on it with the same name as the `attname` but I think that this is the more sane default in that situation as well.