### PR TITLE
BUG: 'bigserial' dtype should not be a cast type

### DIFF
--- a/querybuilder/query.py
+++ b/querybuilder/query.py
@@ -13,6 +13,7 @@ from querybuilder.fields import FieldFactory, CountField, MaxField, MinField, Su
 from querybuilder.helpers import set_value_for_keypath
 from querybuilder.tables import TableFactory, ModelTable, QueryTable
 
+SERIAL_DTYPES = ['serial', 'bigserial']
 
 class Join(object):
     """
@@ -1170,7 +1171,7 @@ class Query(object):
                     db_type = field_object.db_type(self.connection)
 
                     # Don't cast the pk
-                    if db_type == 'serial':
+                    if db_type in SERIAL_DTYPES:
                         placeholders.append('%s')
                     else:
                         # Cast the placeholder to the data type

--- a/querybuilder/query.py
+++ b/querybuilder/query.py
@@ -15,6 +15,7 @@ from querybuilder.tables import TableFactory, ModelTable, QueryTable
 
 SERIAL_DTYPES = ['serial', 'bigserial']
 
+
 class Join(object):
     """
     Represents the JOIN clauses of a Query. The join can be of any join type.


### PR DESCRIPTION
**CHANGES**
- Adds 'bigserial' to list of dtypes which should not be cast in updates

**PROBLEM**
- `django.db.utils.ProgrammingError: type "bigserial" does not exist` error raised when trying to update a field containing an auto incrementing field `BigAutoField` 
 