### PR TITLE
JSON capable cursor

### DIFF
--- a/querybuilder/tests/json_tests.py
+++ b/querybuilder/tests/json_tests.py
@@ -1,5 +1,4 @@
 import unittest
-from django import VERSION
 from django.test.utils import override_settings
 from querybuilder.fields import JsonField
 from querybuilder.query import Query, JsonQueryset
@@ -75,6 +74,7 @@ class JsonFieldTest(QuerybuilderTestCase):
         self.assertEqual(query.select(), [])
 
     # Currently unused (but maybe again sometime) function to check django version for test results
+    # from django import VERSION
     # def is_31_or_above(self):
     #     if VERSION[0] == 3 and VERSION[1] >= 1:
     #         return True

--- a/querybuilder/tests/json_tests.py
+++ b/querybuilder/tests/json_tests.py
@@ -47,11 +47,7 @@ class JsonFieldTest(QuerybuilderTestCase):
             )
         )
 
-        # Django 3.1 changes the raw queryset behavior so querybuilder isn't going to change that behavior
-        if self.is_31_or_above():
-            self.assertEqual(query.select(), [{'my_two_alias': '"two"'}])
-        else:
-            self.assertEqual(query.select(), [{'my_two_alias': 'two'}])
+        self.assertEqual(query.select(), [{'my_two_alias': 'two'}])
 
         query = Query().from_table(MetricRecord, fields=[one_field]).where(**{
             one_field.get_where_key(): '1'
@@ -64,11 +60,7 @@ class JsonFieldTest(QuerybuilderTestCase):
             )
         )
 
-        # Django 3.1 changes the raw queryset behavior so querybuilder isn't going to change that behavior
-        if self.is_31_or_above():
-            self.assertEqual(query.select(), [{'my_one_alias': '1'}])
-        else:
-            self.assertEqual(query.select(), [{'my_one_alias': 1}])
+        self.assertEqual(query.select(), [{'my_one_alias': 1}])
 
         query = Query().from_table(MetricRecord, fields=[one_field]).where(**{
             one_field.get_where_key(): '2'
@@ -82,12 +74,13 @@ class JsonFieldTest(QuerybuilderTestCase):
         )
         self.assertEqual(query.select(), [])
 
-    def is_31_or_above(self):
-        if VERSION[0] == 3 and VERSION[1] >= 1:
-            return True
-        elif VERSION[0] > 3:
-            return True
-        return False
+    # Currently unused (but maybe again sometime) function to check django version for test results
+    # def is_31_or_above(self):
+    #     if VERSION[0] == 3 and VERSION[1] >= 1:
+    #         return True
+    #     elif VERSION[0] > 3:
+    #         return True
+    #     return False
 
 
 @override_settings(DEBUG=True)

--- a/querybuilder/tests/query_tests.py
+++ b/querybuilder/tests/query_tests.py
@@ -52,8 +52,10 @@ class QueryTestCase(QuerybuilderTestCase):
         super(QueryTestCase, self).setUp()
         user1 = G(User, id=1, email='wes.okes@gmail.com')
         user2 = G(User, id=2, email='two+wes.okes@gmail.com')
+        # user3 = G(User, id=3, email='g.e.o.p.h.p.h.r.i.e@gmail.com')
         account1 = G(Account, id=1, user=user1, first_name='Wes', last_name='Okes')
         account2 = G(Account, id=2, user=user2, first_name='Wesley', last_name='Okes')
+        # G(Account, id=3, user=user3, first_name='Geophphrie', last_name='Scors', meta_data={'state': 'TN', 'pets': 1})
 
         G(
             Order, account=account1, revenue=200, margin=100, margin_percent=0.5, time=datetime.datetime(2012, 10, 19))
@@ -145,7 +147,20 @@ class QueryTest(QueryTestCase):
                 received
             )
         )
-
+    # def test_select_sql_with_json(self):
+    #     sql = 'SELECT id, meta_data FROM querybuilder_tests_account ORDER BY id DESC LIMIT 2'
+    #     rows = Query().select(sql=sql)
+    #     received = rows[0]['meta_data']
+    #     expected = Account.objects.all().order_by('-id')[0].meta_data
+    #     self.assert(received instanceOf dict)
+    #     self.assertEqual(
+    #         received,
+    #         expected,
+    #         'Expected {0} but received {1}'.format(
+    #             expected,
+    #             received
+    #         )
+    #     )
     def test_select_sql_args(self):
         sql = 'SELECT id FROM querybuilder_tests_account WHERE id = %(my_id)s'
         sql_args = {

--- a/querybuilder/tests/query_tests.py
+++ b/querybuilder/tests/query_tests.py
@@ -52,10 +52,8 @@ class QueryTestCase(QuerybuilderTestCase):
         super(QueryTestCase, self).setUp()
         user1 = G(User, id=1, email='wes.okes@gmail.com')
         user2 = G(User, id=2, email='two+wes.okes@gmail.com')
-        # user3 = G(User, id=3, email='g.e.o.p.h.p.h.r.i.e@gmail.com')
         account1 = G(Account, id=1, user=user1, first_name='Wes', last_name='Okes')
         account2 = G(Account, id=2, user=user2, first_name='Wesley', last_name='Okes')
-        # G(Account, id=3, user=user3, first_name='Geophphrie', last_name='Scors', meta_data={'state': 'TN', 'pets': 1})
 
         G(
             Order, account=account1, revenue=200, margin=100, margin_percent=0.5, time=datetime.datetime(2012, 10, 19))
@@ -147,20 +145,7 @@ class QueryTest(QueryTestCase):
                 received
             )
         )
-    # def test_select_sql_with_json(self):
-    #     sql = 'SELECT id, meta_data FROM querybuilder_tests_account ORDER BY id DESC LIMIT 2'
-    #     rows = Query().select(sql=sql)
-    #     received = rows[0]['meta_data']
-    #     expected = Account.objects.all().order_by('-id')[0].meta_data
-    #     self.assert(received instanceOf dict)
-    #     self.assertEqual(
-    #         received,
-    #         expected,
-    #         'Expected {0} but received {1}'.format(
-    #             expected,
-    #             received
-    #         )
-    #     )
+
     def test_select_sql_args(self):
         sql = 'SELECT id FROM querybuilder_tests_account WHERE id = %(my_id)s'
         sql_args = {


### PR DESCRIPTION
Add-on to Jared's work that added the json-capable cursor as a function. 
This change applies that same technique to the query builder query classes themselves, so they should function correctly with SQL queries returning jsonb colums in Django 3.1.1+ . Tests that had been modified to work differently in Dj3.1+ were reverted.